### PR TITLE
feat(tracing): enable providing spanOption to callWithSpan

### DIFF
--- a/src/tracing/decorators/v4.ts
+++ b/src/tracing/decorators/v4.ts
@@ -10,7 +10,7 @@ import { asyncCallWithSpan, callWithSpan } from '../utils/tracing';
  * @param descriptor the method descriptor
  * @returns the decorated descriptor
  */
-export function withSpan<This extends { tracer: Tracer }, Args extends unknown[], Return>(
+export function withSpanV4<This extends { tracer: Tracer }, Args extends unknown[], Return>(
   _target: This,
   propertyKey: string | symbol,
   descriptor: TypedPropertyDescriptor<(this: This, ...args: Args) => Return>
@@ -37,7 +37,7 @@ export function withSpan<This extends { tracer: Tracer }, Args extends unknown[]
  * @param descriptor the async method descriptor
  * @returns the decorated descriptor
  */
-export function withSpanAsync<This extends { tracer: Tracer }, Args extends unknown[], Return>(
+export function withSpanAsyncV4<This extends { tracer: Tracer }, Args extends unknown[], Return>(
   _target: This,
   propertyKey: string | symbol,
   descriptor: TypedPropertyDescriptor<(this: This, ...args: Args) => Promise<Return>>

--- a/src/tracing/index.ts
+++ b/src/tracing/index.ts
@@ -4,4 +4,4 @@ export * from './utils/tracing';
 export { getOtelMixin } from './mixin';
 export { logMethod } from './loggerHook';
 export { withSpan, withSpanAsync } from './decorators/v5';
-export { withSpan as withSpanV4, withSpanAsync as withSpanAsyncV4 } from './decorators/v4';
+export { withSpanV4, withSpanAsyncV4 } from './decorators/v4';


### PR DESCRIPTION
SpanOptions optional argument on generating spans

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                      |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

* callWithSpan + asyncCallWithSpan method will able providing spanOption object to configure extra object on span creation

* importing bug on V4 fixing