### PR TITLE
feat: add 3D semantic conventions

### DIFF
--- a/schemas/attribute.schema.json
+++ b/schemas/attribute.schema.json
@@ -6,7 +6,8 @@
   "required": ["domain", "content"],
   "properties": {
     "domain": {
-      "type": "string"
+      "type": "string",
+      "pattern": "^[A-Za-z]"
     },
     "content": {
       "$ref": "#/definitions/recursive"

--- a/src/semanticConventions/3D.json
+++ b/src/semanticConventions/3D.json
@@ -3,7 +3,7 @@
   "content": {
     "propertyName": "mapcolonies.3d",
     "kind": "domain",
-    "description": "name of the domain in use",
+    "description": "Name of the domain in use",
     "deprecated": false,
     "subAttributes": {
       "catalogManager": {
@@ -15,7 +15,7 @@
           "catalogId": {
             "propertyName": "mapcolonies.3d.catalog_manager.catalog_id",
             "deprecated": false,
-            "description": "layer Id as stored on 3D catalog db"
+            "description": "Model ID as stored on 3D catalog DB"
           }
         }
       }

--- a/src/semanticConventions/3D.json
+++ b/src/semanticConventions/3D.json
@@ -1,0 +1,24 @@
+{
+  "domain": "three_d",
+  "content": {
+    "propertyName": "mapcolonies.3d",
+    "kind": "domain",
+    "description": "name of the domain in use",
+    "deprecated": false,
+    "subAttributes": {
+      "catalogManager": {
+        "propertyName": "mapcolonies.3d.catalog_manager",
+        "kind": "catalogManagerAttributes",
+        "description": "attributes related to 3D catalog manager API service",
+        "deprecated": false,
+        "subAttributes": {
+          "catalogId": {
+            "propertyName": "mapcolonies.3d.catalog_manager.catalog_id",
+            "deprecated": false,
+            "description": "layer Id as stored on 3D catalog db"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR add basic semantic conventions for 3D domain

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Unfortunately, a constant can't immediately follow a numeric literal so I set the constant as "THREE_D" instead of '3D'.
I added validation to ensure the domain starts with any letter (and no numbers or any special characters).
