### PR TITLE
fix(tracing): now when debug is enabled the otlp exporter still works

### DIFF
--- a/src/tracing/tracing.ts
+++ b/src/tracing/tracing.ts
@@ -67,11 +67,11 @@ export class Tracing implements TelemetryBase<void> {
     const { serviceVersion, serviceName, traceRatio, ...exporterConfig } = this.config;
 
     const exporter = new OTLPTraceExporter(exporterConfig);
-    let processors: SpanProcessor[] = [new BatchSpanProcessor(exporter)];
+    const processors: SpanProcessor[] = [new BatchSpanProcessor(exporter)];
 
     if (this.config.debug) {
       api.diag.setLogger(new api.DiagConsoleLogger(), api.DiagLogLevel.ALL);
-      processors = [new SimpleSpanProcessor(new ConsoleSpanExporter())];
+      processors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
     }
 
     this.provider = new NodeTracerProvider({


### PR DESCRIPTION
This pull request includes a change to the `Tracing` class in the `src/tracing/tracing.ts` file to improve the handling of span processors. The most important change is the modification of the `processors` variable to be a constant and the addition of a new processor instead of replacing the existing ones when in debug mode.

Improvements to span processor handling:

* [`src/tracing/tracing.ts`](diffhunk://#diff-81a477aea7c9a7f31797ff7021e1e1eb7d556a0458a6bb7ca33784b15dde1547L70-R74): Changed `processors` from a `let` to a `const` and updated the debug mode logic to push a new `SimpleSpanProcessor` to the existing array instead of replacing it.