### PR TITLE
fix: remove up metric

### DIFF
--- a/src/metrics/middleware/metrics.ts
+++ b/src/metrics/middleware/metrics.ts
@@ -186,7 +186,7 @@ export function collectMetricsExpressMiddleware(options: Partial<Opts>): promBun
   const promBundleConfig: promBundle.Opts = {
     promRegistry: mergedOptions.registry,
     autoregister: true,
-    includeUp: true,
+    includeUp: false,
     customLabels: mergedOptions.customLabels,
     includeMethod: true,
     includeStatusCode: true,


### PR DESCRIPTION
This PR removes the "up" metric that causes the duplication of "up" metric in Prometheus

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |